### PR TITLE
Refactor getBrowserNameByOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Stay up to update with new technology and waste all your morning reading everyth
 - [Fatih Arslan](https://github.com/fatih/color)
 - [Martin Angers](https://github.com/PuerkitoBio/goquery)
 - [skratchdot](https://github.com/skratchdot/open-golang)
+- [Corey Prak](https://www.instagram.com/prakattak/)
 
 #### License
 

--- a/main.go
+++ b/main.go
@@ -32,9 +32,11 @@ const (
 )
 
 // Colors for console output
-var blue = color.New(color.FgBlue, color.Bold).SprintFunc()
-var yellow = color.New(color.FgYellow, color.Bold).SprintFunc()
-var red = color.New(color.FgRed, color.Bold).SprintFunc()
+var (
+	blue   = color.New(color.FgBlue, color.Bold).SprintFunc()
+	yellow = color.New(color.FgYellow, color.Bold).SprintFunc()
+	red    = color.New(color.FgRed, color.Bold).SprintFunc()
+)
 
 type logWriter struct{}
 
@@ -223,27 +225,26 @@ func findBrowser(target string) string {
 }
 
 // getBrowserNameByOS normilizes browser name
-func getBrowserNameByOS(k string) string {
-	browser := ""
-	switch k {
-	case "google", "chrome":
-		switch runtime.GOOS {
-		case "darwin":
-			browser = "Google Chrome"
-		}
-	case "mozilla", "firefox":
-		switch runtime.GOOS {
-		case "darwin":
-			browser = "Firefox"
-		}
-	case "brave":
-		switch runtime.GOOS {
-		case "darwin":
-			browser = "Brave"
+func getBrowserNameByOS(denormalizedStr string) string {
+	os := runtime.GOOS
+
+	// key = denormalized value, value = normalized value
+	browserNameMap := map[string]string{
+		"google":  "Google Chrome",
+		"chrome":  "Google Chrome",
+		"mozilla": "Firefox",
+		"firefox": "Firefox",
+		"brave":   "Brave",
+	}
+
+	if os == "darwin" {
+		normalizedStr, ok := browserNameMap[denormalizedStr]
+		if ok {
+			return normalizedStr
 		}
 	}
 
-	return browser
+	return ""
 }
 
 // checkGoPath checks for GOPATH

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,4 +47,26 @@ func TestGetLobstersStories(t *testing.T) {
 
 	assert.NotNil(t, news)
 	assert.Equal(t, 10, len(news), "They should be equal")
+}
+
+func TestGetBrowserNameByOS(t *testing.T) {
+	// For now, getBrowserName only assumes the logic below
+	// applies to the darwin OS; add subtests as more os values
+	// are added.
+	if runtime.GOOS == "darwin" {
+		t.Run("Validate Darwin OS", func(t *testing.T) {
+			browserNameMap := map[string][]string{
+				"Google Chrome": []string{"google", "chrome"},
+				"Firefox":       []string{"mozilla", "firefox"},
+				"Brave":         []string{"brave"},
+			}
+
+			// test every possible browser string value
+			for normalizedStr, browserStrSlice := range browserNameMap {
+				for _, browserStr := range browserStrSlice {
+					assert.Equal(t, getBrowserNameByOS(browserStr), normalizedStr)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
`getBrowserNameByOS` doesn't have unit tests, so I decided to add one. 

Right now, it's basically a subtest that runs based on the value of `runtime.GOOS` since the way `getBrowserNameByOS` is written is only meant to handle cases where we're dealing with a `darwin` based OS. Not only does the unit test do that, but it tests every possible denormalized string value.

I was thinking that since the function only handles cases for a `darwin` OS, we can ensure that any other value for `runtime.GOOS` will result in a return value of a null string. While it does adhere to the current behavior, I feel like it could be overkill.

The code for it also seemed like it could have been simplified a bit for a few reasons:

- variable name 'k' for the sole string argument didn't seem like it provided any context as to what the argument was
- doubly nested `switch, case` blocks for basic logic just seemed like it could be simplified.

To ensure that my changes to the function work as intended, I created the test, ran the entire test suite and ensured it passed, modified `getBrowserNameByOS`, then ran tests a final time to ensure its behavior remained unchanged.