### PR TITLE
ISSUE#21: Browser name find for linux and windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ _testmain.go
 
 # Executable
 /hnreader
+
+# Workflow tools
+Makefile

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/jzelinskie/geddit"
 	"github.com/skratchdot/open-golang/open"
 	"github.com/texttheater/golang-levenshtein/levenshtein"
-	"gopkg.in/urfave/cli.v2"
+	cli "gopkg.in/urfave/cli.v2"
 )
 
 // App information and constants
@@ -26,9 +26,16 @@ const (
 	AppVersion     = "v1.1"
 	AppAuthor      = "Bunchhieng Soth"
 	AppEmail       = "Bunchhieng@gmail.com"
-	AppDescription = "Open multiple news feed in your favorite browser with command line."
+	AppDescription = "Open multiple tech news feeds in your favorite browser through the command line."
 	HackerNewsURL  = "https://news.ycombinator.com/news?p="
 	LobstersURL    = "https://lobste.rs"
+)
+
+// Supported operating systems (GOOS)
+const (
+	OSDarwin  = "darwin"
+	OSLinux   = "linux"
+	OSWindows = "windows"
 )
 
 // Colors for console output
@@ -219,31 +226,56 @@ func findBrowser(target string) string {
 		}
 	}
 
-	return getBrowserNameByOS(word)
+	return getBrowserNameByOS(word, runtime.GOOS)
+}
+
+func getGoogleChromeNameForOS(os string) string {
+	switch os {
+	case OSDarwin:
+		return "Google Chrome"
+	case OSLinux:
+		return "google-chrome"
+	case OSWindows:
+		return "chrome"
+	}
+	return ""
+}
+
+func getFirefoxNameForOS(os string) string {
+	switch os {
+	case OSDarwin:
+		return "Firefox"
+	case OSLinux:
+		return "firefox"
+	case OSWindows:
+		return "firefox"
+	}
+	return ""
+}
+
+func getBraveNameForOS(os string) string {
+	switch os {
+	case OSDarwin:
+		return "Brave"
+	case OSLinux:
+		return "brave"
+	case OSWindows:
+		return "brave"
+	}
+	return ""
 }
 
 // getBrowserNameByOS normilizes browser name
-func getBrowserNameByOS(k string) string {
-	browser := ""
-	switch k {
+func getBrowserNameByOS(browserFromCLI, os string) string {
+	switch browserFromCLI {
 	case "google", "chrome":
-		switch runtime.GOOS {
-		case "darwin":
-			browser = "Google Chrome"
-		}
+		return getGoogleChromeNameForOS(os)
 	case "mozilla", "firefox":
-		switch runtime.GOOS {
-		case "darwin":
-			browser = "Firefox"
-		}
+		return getFirefoxNameForOS(os)
 	case "brave":
-		switch runtime.GOOS {
-		case "darwin":
-			browser = "Brave"
-		}
+		return getBraveNameForOS(os)
 	}
-
-	return browser
+	return ""
 }
 
 // checkGoPath checks for GOPATH
@@ -291,13 +323,13 @@ func main() {
 						Name:    "tabs",
 						Value:   10,
 						Aliases: []string{"t"},
-						Usage:   "Specify value of tabs\t",
+						Usage:   "Specify number of tabs\t",
 					},
 					&cli.StringFlag{
 						Name:    "browser",
 						Value:   "",
 						Aliases: []string{"b"},
-						Usage:   "Specify broswer\t",
+						Usage:   "Specify browser\t",
 					},
 					&cli.StringFlag{
 						Name:    "source",
@@ -310,7 +342,7 @@ func main() {
 					var src Fetcher
 
 					switch c.String("source") {
-					case "hn":
+					case "hn", "hackernews":
 						src = new(HackerNewsSource)
 					case "reddit":
 						src = new(RedditSource)

--- a/main_test.go
+++ b/main_test.go
@@ -47,3 +47,29 @@ func TestGetLobstersStories(t *testing.T) {
 	assert.NotNil(t, news)
 	assert.Equal(t, 10, len(news), "They should be equal")
 }
+
+func TestGetBrowserNameByOS(t *testing.T) {
+
+	assertErrMsg := "They should be equal"
+
+	os := "darwin"
+	assert.Equal(t, "Firefox", getBrowserNameByOS("firefox", os), assertErrMsg)
+	assert.Equal(t, "Firefox", getBrowserNameByOS("mozilla", os), assertErrMsg)
+	assert.Equal(t, "Google Chrome", getBrowserNameByOS("chrome", os), assertErrMsg)
+	assert.Equal(t, "Google Chrome", getBrowserNameByOS("google", os), assertErrMsg)
+	assert.Equal(t, "Brave", getBrowserNameByOS("brave", os), assertErrMsg)
+
+	os = "linux"
+	assert.Equal(t, "firefox", getBrowserNameByOS("firefox", os), assertErrMsg)
+	assert.Equal(t, "firefox", getBrowserNameByOS("mozilla", os), assertErrMsg)
+	assert.Equal(t, "google-chrome", getBrowserNameByOS("chrome", os), assertErrMsg)
+	assert.Equal(t, "google-chrome", getBrowserNameByOS("google", os), assertErrMsg)
+	assert.Equal(t, "brave", getBrowserNameByOS("brave", os), assertErrMsg)
+
+	os = "windows"
+	assert.Equal(t, "firefox", getBrowserNameByOS("firefox", os), assertErrMsg)
+	assert.Equal(t, "firefox", getBrowserNameByOS("mozilla", os), assertErrMsg)
+	assert.Equal(t, "chrome", getBrowserNameByOS("chrome", os), assertErrMsg)
+	assert.Equal(t, "chrome", getBrowserNameByOS("google", os), assertErrMsg)
+	assert.Equal(t, "brave", getBrowserNameByOS("brave", os), assertErrMsg)
+}


### PR DESCRIPTION
Browser names need to be converted from the normalized name
given in the command line (e.g. "chrome") to
a name that matches the associated executable on the
operating system (e.g. "Google Chrome" on macos or "google-chrome" on
linux).

This commit adds support of this function for windows and linux
additionally to the existing support for macos (darwin).

Signed-off-by: FrontSide <david@isan.engineer>